### PR TITLE
Add extra_headers support to provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,3 +27,4 @@ provider "traceforce" {
 
 - `api_key` (String) API key to the service
 - `endpoint` (String) Service endpoint
+- `extra_headers` (Map of String) Additional headers to include in API requests

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/traceforce/traceforce-go-sdk v1.0.11
+	github.com/traceforce/traceforce-go-sdk v1.0.12
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/traceforce/traceforce-go-sdk v1.0.11 h1:+zJzbaWrG/Cfx/BIePJPXpqn7LJcbqKyIIF8ZPQPiMg=
-github.com/traceforce/traceforce-go-sdk v1.0.11/go.mod h1:tGUpoMFqNetpaHCGB5VBickq3Cf22OEnHtPC7yg0obk=
+github.com/traceforce/traceforce-go-sdk v1.0.12 h1:xFxCfg6+f7WpkhQVJ26+YW4erew3SuqNths1RwrDAz4=
+github.com/traceforce/traceforce-go-sdk v1.0.12/go.mod h1:tGUpoMFqNetpaHCGB5VBickq3Cf22OEnHtPC7yg0obk=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION

## Description

- Add extra_headers configuration option to provider schema
- Update to traceforce-go-sdk v1.0.12 with extra headers support
- Allow passing additional headers for preview/staging environments
- Update generated documentation
- 
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
