### PR TITLE
increase patch version of go sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/traceforce/traceforce-go-sdk v1.0.14
+	github.com/traceforce/traceforce-go-sdk v1.0.15
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/traceforce/traceforce-go-sdk v1.0.14 h1:FUrpUz+lS4XIRkStSPFZUf770EXnXj//uAol3OyFsZs=
-github.com/traceforce/traceforce-go-sdk v1.0.14/go.mod h1:tGUpoMFqNetpaHCGB5VBickq3Cf22OEnHtPC7yg0obk=
+github.com/traceforce/traceforce-go-sdk v1.0.15 h1:qL5NYdzW29ySJvThq/CBD6lS3QmUaEa76v3sBfMpxK8=
+github.com/traceforce/traceforce-go-sdk v1.0.15/go.mod h1:tGUpoMFqNetpaHCGB5VBickq3Cf22OEnHtPC7yg0obk=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION


## Description

increase patch version of go sdk to remove terraform version hash

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
